### PR TITLE
Improve FilePathExtractor: batch handling and path normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ After installing the `ComfyUI-FilePathCreator`, you can use it to generate filen
 The `FilePathExtractor` is a custom node extension for ComfyUI designed to extract components from a given file or folder path. This node facilitates the decomposition of file paths into understandable and reusable parts, enhancing workflow automation and path management.
 
 ### Features
-- **Path Input**: Accepts a path to a file or folder.
+- **Path Input**: Accepts one or many paths (batch/list compatible) to files or folders.
 - **Extract File Name**: Retrieves the name of the file without the extension.
 - **Extract File Extension**: Identifies the file's extension.
 - **File Name With Extension**: Retrieves the filename along with its extension.
 - **Extract Folder Name**: Gets the name of the folder containing the file.
-- **Extract Folder Path**: Provides the absolute path to the folder.
+- **Extract Folder Path**: Provides the folder path (or the original text if no directory segment is present).
+- **Batch-Friendly Output**: Works with ComfyUI list processing by returning one value per input path in each output socket.
 
 ### Inputs
 1. **path** (required): 
@@ -63,10 +64,10 @@ The `FilePathExtractor` is a custom node extension for ComfyUI designed to extra
 
 ### Outputs
 1. **File Name**: The name of the file extracted from the path.
-2. **File Extension**: The extension of the file.
+2. **File Extension**: The extension of the file (without the leading dot).
 3. **File Name With Extension**: The filename along with its extension.
 4. **Folder Name**: The name of the folder containing the file.
-5. **Folder Path**: The absolute path to the folder.
+5. **Folder Path**: The derived folder path (or original input if no folder segment exists).
 
 ### Example Usage
 After installing the `FilePathExtractor`, you can input a file path like `C:/Folder/FolderName/Filename.png` and obtain:

--- a/file_path_extractor.py
+++ b/file_path_extractor.py
@@ -1,11 +1,12 @@
 import os
 
+
 class FilePathExtractor:
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "path": ("STRING", {"default": "", "multiline": True, "width": 400})  # Adjust height
+                "path": ("STRING", {"default": "", "multiline": True, "width": 400})
             }
         }
 
@@ -13,17 +14,58 @@ class FilePathExtractor:
     RETURN_TYPES = ("STRING", "STRING", "STRING", "STRING", "STRING")
     RETURN_NAMES = ("File Name", "File Extension", "File Name With Extension", "Folder Name", "Folder Path")
     FUNCTION = "process"
+    INPUT_IS_LIST = True
+    OUTPUT_IS_LIST = (True, True, True, True, True)
 
     @staticmethod
     def IS_CHANGED():
         # Always return True to force the node to run on every iteration
         return True
 
-    def process(self, path):
-        folder_path = os.path.dirname(path) if os.path.dirname(path) else path  # Use folder part of the path, even if it doesn't exist
-        folder_name = os.path.basename(folder_path)
-        file_name_with_extension = os.path.basename(path)
-        file_name, file_extension = os.path.splitext(file_name_with_extension)
-        file_extension = file_extension[1:]  # Strip leading dot from extension
+    @classmethod
+    def _normalize_paths(cls, path):
+        normalized_paths = []
 
-        return file_name, file_extension, file_name_with_extension, folder_name, folder_path
+        def _flatten(value):
+            if isinstance(value, (list, tuple)):
+                for item in value:
+                    _flatten(item)
+                return
+
+            if value is None:
+                normalized_paths.append("")
+            else:
+                normalized_paths.append(str(value))
+
+        _flatten(path)
+
+        if not normalized_paths:
+            return [""]
+
+        return normalized_paths
+
+    def process(self, path):
+        paths = self._normalize_paths(path)
+
+        file_names = []
+        file_extensions = []
+        file_names_with_extension = []
+        folder_names = []
+        folder_paths = []
+
+        for path_item in paths:
+            folder_part = os.path.dirname(path_item)
+            # Keep original text when no directory part is present.
+            folder_path = folder_part if folder_part else path_item
+            folder_name = os.path.basename(folder_path)
+            file_name_with_extension = os.path.basename(path_item)
+            file_name, file_extension = os.path.splitext(file_name_with_extension)
+            file_extension = file_extension[1:] if file_extension.startswith(".") else file_extension
+
+            file_names.append(file_name)
+            file_extensions.append(file_extension)
+            file_names_with_extension.append(file_name_with_extension)
+            folder_names.append(folder_name)
+            folder_paths.append(folder_path)
+
+        return file_names, file_extensions, file_names_with_extension, folder_names, folder_paths


### PR DESCRIPTION
### Motivation
- Make the extractor robust for ComfyUI workflows that pass lists/batches of paths instead of single strings.  
- Handle mixed and nested inputs (lists/tuples and `None`) safely so the node doesn't error or drop items.  
- Preserve expected semantics when a path has no directory part and produce consistent extension output without a leading dot.

### Description
- Added `INPUT_IS_LIST = True` and `OUTPUT_IS_LIST = (True, True, True, True, True)` to enable list/batch-compatible inputs and outputs.  
- Implemented a `_normalize_paths` helper that recursively flattens nested lists/tuples and converts `None` to `""`, while ensuring a fallback empty entry for totally empty input.  
- Switched `process` to iterate normalized paths and return lists for each socket, keeping `folder_path` equal to the original input when no directory segment exists and stripping the leading `.` from extensions.  
- Updated `README.md` to document batch/list input support and clarified folder-path and extension output behavior.

### Testing
- Compiled the package with `python -m compileall .` and it succeeded.  
- Ran a manual functional smoke test using `from file_path_extractor import FilePathExtractor` and `FilePathExtractor().process([['/tmp/test/file.txt', None], 'justname', '/a/b/c.tar.gz'])`, which produced the expected list-shaped outputs.  
- Verified files load without syntax errors by importing the module in a Python REPL; no failures observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b413b114f483298a8bad504125672d)